### PR TITLE
dev: Remove isStatic path from rendering logic

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import { usePageContext } from "utils/client/hooks";
 import styles from "./Header.module.scss";
 
 const Header = () => {
-	const { session, isStatic } = usePageContext();
+	const { session } = usePageContext();
 	const user = session?.user;
 	return (
 		<nav className={styles.header}>
@@ -78,11 +78,11 @@ const Header = () => {
 								/>
 							</Popover>
 						</>
-					) : isStatic === false ? (
+					) : (
 						<Button is="a" href="/login" appearance="minimal" height={40}>
 							Login
 						</Button>
-					) : null}
+					)}
 				</Pane>
 			</div>
 		</nav>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,14 +10,13 @@ import { setCachedSession } from "utils/server/session";
 import { PageData } from "utils/shared/session";
 
 import "./app.scss";
-import { IncomingMessage } from "http";
 
 type ExpandedAppProps = AppProps & PageData;
 
-const App = ({ Component, pageProps, session, isStatic }: ExpandedAppProps) => {
+const App = ({ Component, pageProps, session }: ExpandedAppProps) => {
 	return (
 		<ThemeProvider value={theme}>
-			<PageContext.Provider value={{ session, isStatic }}>
+			<PageContext.Provider value={{ session }}>
 				<div className="app">
 					<Header />
 					<div id="main-content" tabIndex={-1}>
@@ -31,20 +30,9 @@ const App = ({ Component, pageProps, session, isStatic }: ExpandedAppProps) => {
 };
 
 App.getInitialProps = async ({ ctx }: AppContext): Promise<PageData> => {
-	// App.getInitialProps actually gets invoked in two different contexts:
-	// 1. at build time for any pages that opt into static generation by using getStaticProps, and
-	// 2. for every new request at runtime.
-	// In the first case (build time), `ctx.req` exists but is a mock request object
-	// (just .path and a few other known properties); at runtime, ctx.req is an IncomingMessage
-	if (ctx.req instanceof IncomingMessage) {
-		// This happens at runtime.
-		const session = await getSession(ctx);
-		setCachedSession(ctx, session);
-		return { session, isStatic: false };
-	} else {
-		// This happens at build time.
-		return { session: null, isStatic: true };
-	}
+	const session = await getSession(ctx);
+	setCachedSession(ctx, session);
+	return { session };
 };
 
 export default App;

--- a/pages/docs/[[...path]].tsx
+++ b/pages/docs/[[...path]].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 
 import { readdirSync, lstatSync, existsSync, readFileSync } from "fs";
 import { resolve } from "path";
@@ -7,26 +7,6 @@ import { DocFrame } from "components";
 import { useRouter } from "next/router";
 
 const docsRoot = resolve("docs");
-
-function* traverseDocsDirectory(
-	path: string[]
-): Generator<{ params: DocsParams }, void, undefined> {
-	for (const name of readdirSync(resolve(docsRoot, ...path))) {
-		const stat = lstatSync(resolve(docsRoot, ...path, name));
-		if (stat.isDirectory()) {
-			yield* traverseDocsDirectory([...path, name]);
-		} else if (name.endsWith(".md")) {
-			const urlPath =
-				name === "index.md" ? [...path] : [...path, name.slice(0, name.lastIndexOf(".md"))];
-			yield { params: { path: urlPath } };
-		}
-	}
-}
-
-export async function getStaticPaths() {
-	const paths = Array.from(traverseDocsDirectory([]));
-	return { paths, fallback: false };
-}
 
 interface DocsProps {
 	content: string;
@@ -63,7 +43,7 @@ function getSubSections(section: string): string[] {
 	return subSections;
 }
 
-export const getStaticProps: GetStaticProps<DocsProps, DocsParams> = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps<DocsProps, DocsParams> = async ({ params }) => {
 	if (params === undefined) {
 		return { notFound: true };
 	}

--- a/utils/client/hooks.tsx
+++ b/utils/client/hooks.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { PageData } from "utils/shared/session";
 import { LocationData } from "utils/shared/urls";
 
-export const PageContext = React.createContext<PageData>({ session: null, isStatic: true });
+export const PageContext = React.createContext<PageData>({ session: null });
 export const usePageContext = (): PageData => useContext(PageContext);
 
 export const LocationContext = React.createContext<LocationData>({});

--- a/utils/shared/session.ts
+++ b/utils/shared/session.ts
@@ -4,7 +4,6 @@ import { Session } from "next-auth/client";
 
 export interface PageData {
 	session: ClientSession | null;
-	isStatic: boolean;
 }
 
 export interface ClientUser {

--- a/utils/storybook/contexts.tsx
+++ b/utils/storybook/contexts.tsx
@@ -10,7 +10,6 @@ import { NextRouter } from "next/dist/next-server/lib/router/router";
 import { PageData } from "utils/shared/session";
 
 const loggedIn: PageData = {
-	isStatic: false,
 	session: {
 		user: {
 			id: "1",


### PR DESCRIPTION
This PR simplifies the `_app.tsx` logic by removing the `isStatic` rendering pathway. 

`isStatic` was added to allow certain static pages (e.g. doc pages) to be rendered at build-time, rather than at request-time. The trade-off associated with this is that the normal server-side approach to fetching login information (e.g. being able to render the user's icon and login-status in the top-right corner) would no longer work.

Running some informal (i.e. not large-number aggregated) performance tests on the difference between these two options makes me feel that the performance benefits at this early stage are not worth the added complexity (and lack of consistency) in how `pages` render and work. 

Static rendering of doc pages typically resulted in a first draw after ~30-40ms, while the server-side approach typically took ~55-65ms. Both figures are significantly overshadowed by the time it takes for codemirror to load and render highlighted content (~600-700ms).

## Static Render
![Screen Shot 2020-12-10 at 1 30 23 PM](https://user-images.githubusercontent.com/1000455/101814932-b3651e80-3b16-11eb-911e-383bffed2e74.png)

## Server Render
![Screen Shot 2020-12-10 at 1 28 51 PM](https://user-images.githubusercontent.com/1000455/101814951-bd871d00-3b16-11eb-83f5-14b494967e71.png)

The static approach also has the somewhat unintuitive (but minimal) side-effect of making every page load larger due to the added logic for implementing `isStatic` (~150kB as opposed to 126kB).

## Static Render Build
![Screen Shot 2020-12-10 at 1 10 40 PM](https://user-images.githubusercontent.com/1000455/101815098-ef987f00-3b16-11eb-97ff-5082ad3dc9ab.png)

## Server Render Build
![Screen Shot 2020-12-10 at 1 26 10 PM](https://user-images.githubusercontent.com/1000455/101815165-0fc83e00-3b17-11eb-87df-b47e7a2f36c3.png)

